### PR TITLE
Fix page title of landing page

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -1,5 +1,5 @@
 <!-- See structure.html for the template names used here and their position in the layout. -->
-{{define "title"}}Team Silverblue &mdash; Stories{{end}}
+{{define "title"}}Team Silverblue{{end}}
 
 {{define "body"}}
 <article>


### PR DESCRIPTION
The landing page shows up in google searches for "Team Silverblue"
as "Team Silverblue - Stories". That title was meant for stories
page, lets keep it to just "Team Silverblue" for the landing
page.