### PR TITLE
Move blogs

### DIFF
--- a/pages/elsewhere/index.html
+++ b/pages/elsewhere/index.html
@@ -42,10 +42,7 @@ and related subprojects here.</p>
 <li>David King, Flock 2016: Towards an Atomic Workstation,
 <a href="https://www.youtube.com/watch?v=-wwVvm42gpE">Video</a>
 
-
 </ul>
-
-</article>
 
 <h1>Press</h1>
 
@@ -62,5 +59,6 @@ and related subprojects here.</p>
 <li>golem.de, <a href="https://www.golem.de/news/team-silverblue-fedora-will-modularen-desktop-fuer-alle-1805-134263.html">Fedora will modularen Desktop für alle</a> (German)
 </ul>
 
+</article>
 
 {{end}}

--- a/pages/elsewhere/index.html
+++ b/pages/elsewhere/index.html
@@ -59,6 +59,28 @@ and related subprojects here.</p>
 <li>golem.de, <a href="https://www.golem.de/news/team-silverblue-fedora-will-modularen-desktop-fuer-alle-1805-134263.html">Fedora will modularen Desktop für alle</a> (German)
 </ul>
 
+<h1>Blogs</h1>
+
+  <p>Matthias has written a series of blog posts about his experience learning his
+  way around Silverblue, when it was still called Fedora Atomic Workstation:</p>
+
+  <ul>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/08/first-steps-with-fedora-atomic-workstation/">First steps</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/11/fedora-atomic-workstation-what-about-apps/">What about apps?</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/14/fedora-atomic-workstation-building-flatpaks/">Building flatpaks</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/16/fedora-atomic-workstation-for-development/">For development</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/21/fedora-atomic-workstation-works-on-the-beach/">Works on the beach</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/02/24/fedora-atomic-workstation-on-the-road/">On the road</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/03/08/fedora-atomic-workstation-trying-things-out-the-easy-way/">Trying things out the easy way</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/03/16/fedora-atomic-workstation-ruling-the-commandline/">Ruling the commandline</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/03/22/fedora-atomic-workstation-almost-fool-proof/">Almost foolproof</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/04/03/fedora-atomic-workstation-beta/">Beta</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/04/16/fedora-atomic-workstation-developer-tools/">Developer tools</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/04/27/fedora-atomic-workstation-developer-tools-continued/">Developer tools, continued</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/04/29/fedora-atomic-workstation-theming-possible/">Theming possible</a>
+  <li><a href="https://blogs.gnome.org/mclasen/2018/05/04/fedora-atomic-workstation-getting-comfortable-with-gnome-builder/">Getting comfortable with GNOME Builder</a>
+  </ul>
+
 </article>
 
 {{end}}

--- a/pages/elsewhere/index.html
+++ b/pages/elsewhere/index.html
@@ -44,21 +44,6 @@ and related subprojects here.</p>
 
 </ul>
 
-<h1>Press</h1>
-
-<ul>
-
-<li>LWN, <a href="https://lwn.net/Articles/753293/">Fedora Atomic Workstation becomes Team Silverblue</a>
-
-<li>Phoronix, <a href="https://www.phoronix.com/scan.php?page=news_item&px=Atomic-Team-Silverblue">Team Silverblue Succeeds Fedora Atomic Workstation, Aims To Be In Great Shape By F30</a>
-
-<li>Linux News, <a href="https://linuxnews.de/2018/05/03/neue-fedora-initiative-team-silverblue/">Neue Fedora-Initiative »Team Silverblue«</a> (German)
-
-<li>Pro-Linux.de, <a href="http://www.pro-linux.de/news/1/25864/fedora-atomic-workstation-wird-zu-team-silverblue.html">Fedora Atomic Workstation wird zu Team Silverblue</a> (German)
-
-<li>golem.de, <a href="https://www.golem.de/news/team-silverblue-fedora-will-modularen-desktop-fuer-alle-1805-134263.html">Fedora will modularen Desktop für alle</a> (German)
-</ul>
-
 <h1>Blogs</h1>
 
   <p>Matthias has written a series of blog posts about his experience learning his
@@ -80,6 +65,28 @@ and related subprojects here.</p>
   <li><a href="https://blogs.gnome.org/mclasen/2018/04/29/fedora-atomic-workstation-theming-possible/">Theming possible</a>
   <li><a href="https://blogs.gnome.org/mclasen/2018/05/04/fedora-atomic-workstation-getting-comfortable-with-gnome-builder/">Getting comfortable with GNOME Builder</a>
   </ul>
+
+  <p>Tom Whiston has also written some nice blog posts about containerizing his desktop:</p>
+
+  <ul>
+    <li><a href="https://www.nine.ch/en/engineering-logbook/dockerising-my-workstation-with-atomic-part-1">Part 1: Introduction</a>
+    <li><a href="https://www.nine.ch/en/engineering-logbook/dockerising-my-workstation-with-atomic-part-2">Part 2: Containerizing an IDE</a>
+  </ul>
+
+<h1>Press</h1>
+
+<ul>
+
+<li>LWN, <a href="https://lwn.net/Articles/753293/">Fedora Atomic Workstation becomes Team Silverblue</a>
+
+<li>Phoronix, <a href="https://www.phoronix.com/scan.php?page=news_item&px=Atomic-Team-Silverblue">Team Silverblue Succeeds Fedora Atomic Workstation, Aims To Be In Great Shape By F30</a>
+
+<li>Linux News, <a href="https://linuxnews.de/2018/05/03/neue-fedora-initiative-team-silverblue/">Neue Fedora-Initiative »Team Silverblue«</a> (German)
+
+<li>Pro-Linux.de, <a href="http://www.pro-linux.de/news/1/25864/fedora-atomic-workstation-wird-zu-team-silverblue.html">Fedora Atomic Workstation wird zu Team Silverblue</a> (German)
+
+<li>golem.de, <a href="https://www.golem.de/news/team-silverblue-fedora-will-modularen-desktop-fuer-alle-1805-134263.html">Fedora will modularen Desktop für alle</a> (German)
+</ul>
 
 </article>
 


### PR DESCRIPTION
I feel that the blogs are a better fit in the "Elsewhere" section next to talks and press.
I'll have a matching pr for the docs to remove them there.