### PR TITLE
Custom 404

### DIFF
--- a/pages/contribute/index.html
+++ b/pages/contribute/index.html
@@ -33,6 +33,9 @@ We accept pull requests and do not require a CLA.</p>
 </ul>
 Feel free to come by!</p>
 
+<p>You can also read the <a href="/contribute/meeting-logs">summaries</a>
+of previous meetings.</p>
+
 <p>Outside of the meeting, you can always come by and chat about Silverblue
 in the &num;silverblue IRC channel on freenode.</p>
 

--- a/pages/contribute/meeting-logs.html
+++ b/pages/contribute/meeting-logs.html
@@ -1,0 +1,94 @@
+<!-- See structure.html for the template names used here and their position in the layout. -->
+{{define "title"}}Team Silverblue &mdash; Contribute{{end}}
+
+{{define "body"}}
+<article>
+
+<h1>Meeting Summaries</h1>
+
+<h3>Notes from IRC meetings</h3>
+
+<ul>
+  <li><a href="https://meetbot.fedoraproject.org/fedora-meeting-2/2018-06-11/team_silverblue.2018-06-11-13.01.html">June 11, 2018</a>
+  <li><a href="https://meetbot.fedoraproject.org/fedora-meeting-2/2018-04-30/faw_sig.2018-04-30-13.00.html">April 30, 2018</a>
+  <li><a href="https://meetbot.fedoraproject.org/fedora-meeting-2/2018-04-16/atomic_workstation_sig.2018-04-16-13.05.html">April 16, 2018</a>
+  <li><a href="https://meetbot.fedoraproject.org/fedora-meeting-2/2018-03-19/atomic_workstation_sig.2018-03-19-14.02.html">March 19, 2018</a>
+  <li><a href="https://meetbot.fedoraproject.org/teams/fedora_atomic_workstation/fedora_atomic_workstation.2018-03-05-14.04.log.html">March 5, 2018</a>
+</ul>
+
+<h3>Notes from the call on Feb 19, 2018</h3>
+
+<h4>Agenda: on Fedora wiki, Workstation/AtomicWorkstation/SIG/Agenda</h4>
+<h4>Participants:</h4>
+<ul>
+  <li>Sanja Bonic
+  <li>Owen Taylor
+  <li>Matthias Clasen
+  <li>Jeff Ligon
+  <li>Jonathan Lebon
+  <li>Suraj Narwade
+  <li>Micah Abbott
+  <li>Steve Milner
+  <li>Kalev Lember
+  <li>Allan Day
+</ul>
+
+<h4>Topic: Meeting time and venue</h4>
+
+<p><b>Decision:</b> Future meetings will be on irc, same time, bi-weekly. Well aim for 45 minutes
+since some of us have another meeting at 9:45.<br>
+No recording, we'll take notes</p>
+
+<h4>Topic: Fedora 28 goals</h4>
+
+<p>The big feature in Fedora 28 will be rpm-ostree support in GNOME software<br>
+We'll also have proper website for FAW (as part of the Project Atomic website)<br>
+<b>Future topic:</b> release planning:
+<ul>
+  <li>how do we go from alpha to beta to final ?
+  <li>make sure we have a FAW release at GA time, not delayed
+  <li>how frequently do we want composes ?
+  <li>is there any form of gating for the images ?
+</ul>
+</p>
+
+<p>In discussion around update frequency, Kalev points out that it would be good to sync
+the OSTree updates with package repo metadata updates. See this:
+<a href="https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/MFXURKYAIMHU27JR36GENXLCKL2QML6R/">discussion</a></p>
+
+<p>The experimental jigdo transport for rpm-ostree also came up in this discussion as a
+possible solution for 'split package version' situations. This is not aimed at F28 though,
+more likely F30.</p>
+
+<h4>Topic: Status of composes</h4>
+
+<p>Is there a person responsible for FAW composes in rel-eng ? Not particularly :-(<br>
+This page tracks it somewhat: <a href="https://www.happyassassin.net/nightlies.html">https://www.happyassassin.net/nightlies.html</a> - Workstation dvd-ostree on that page is the FAW installer image<br>
+Rawhide composes have not been working for quite some time, recently fixed: <a href="https://pagure.io/atomic-wg/issue/409">https://pagure.io/atomic-wg/issues/409</a><br>
+F27 composes have been happening though</p>
+
+<p>In discussion of composes, the question of the two branches (f27 and updates) came up. The branches work slightly differently from the package repos of the same name: the f27 package repo is frozen in time, while the f27 branch in OSTree still moves forward, just at a more granular pace than updates (at least in theory, we were not exactly clear if any gating happens for this currently).</p>
+
+<p>Future topic that came up here: How do we determine the package set ? Do we differentiate more from FAH or move closer to the regular workstation ? Installing default apps as flatpaks helps for this.</p>
+
+<h4>Topic: Status of Flatpaks from rpms in Fedora</h4>
+
+<p>Everything is lined up<br>
+    New person on the rel-eng side is starting<br>
+    Still a few weeks away from seeing the first flatpak produced in this way</p>
+
+<h4>Topic: Website</h4>
+
+<p>Currently here: http://new.projectatomic.io<br>
+    Will have a section on FAW<br>
+    Will replace www.projectatomic.io soon</p>
+
+<h4>Topic: Issue tracking</h4>
+
+<p>Currently, we have a very non-obvious pagure project for it<br>
+    Owen suggests that we create an empty project for it. Atomic wg does that: https://pagure.io/atomic-wg/issues<br>
+    <b>Decision:</b> we will do the same</p>
+
+</article>
+
+{{end}}

--- a/pages/notfound.html
+++ b/pages/notfound.html
@@ -1,0 +1,6 @@
+<!-- See structure.html for the template names used here and their position in the layout. -->
+{{define "title"}}Team Silverblue{{end}}
+
+{{define "body"}}
+<img src="/public/notfound.svg"/>
+{{end}}

--- a/public/notfound.svg
+++ b/public/notfound.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 400 400"
+   width="100%">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-722.51965)"
+     id="layer1">
+    <rect
+       y="984.05652"
+       x="133.4613"
+       height="50.270832"
+       width="49.514877"
+       id="rect826"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <rect
+       transform="matrix(0.84866032,0.52893824,-0.53575837,0.84437134,0,0)"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3.00004888;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+       id="rect828"
+       width="21.149254"
+       height="80.930511"
+       x="618.78101"
+       y="747.79865" />
+    <circle
+       r="40.357143"
+       cy="868.23395"
+       cx="143.57143"
+       id="path839"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <g
+       id="text857"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:63.67200089px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#4a90d9;fill-opacity:1;stroke:none;stroke-width:1"
+       aria-label="?">
+      <path
+         id="path859"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:63.67200089px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1"
+         d="m 142.51359,875.69989 h 4.58438 c -1.01875,-8.91408 9.23244,-12.2887 9.23244,-20.62973 0,-6.30353 -4.3297,-10.18752 -10.88791,-10.18752 -4.52071,0 -8.02267,2.22852 -10.6969,5.28478 l 2.99259,2.73789 c 1.97383,-2.29219 4.52071,-3.69297 7.32228,-3.69297 4.075,0 6.17618,2.80157 6.17618,6.17618 0,6.74923 -10.12385,10.37854 -8.72306,20.31137 z m -1.33712,9.42346 c 0,2.29219 1.65548,3.94766 3.75665,3.94766 2.10118,0 3.82032,-1.65547 3.82032,-3.94766 0,-2.41954 -1.71914,-4.07501 -3.82032,-4.07501 -2.10117,0 -3.75665,1.65547 -3.75665,4.07501 z" />
+    </g>
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+       id="circle862"
+       cx="213.14285"
+       cy="871.09113"
+       r="8.9285717" />
+    <circle
+       r="4.6428576"
+       cy="880.94824"
+       cx="248.64285"
+       id="circle864"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path970"
+       d="m 261.12443,904.07416 c 0,0 18.18275,-20.45559 31.31473,-18.43528 13.13199,2.0203 16.41498,17.67767 16.41498,23.73858 0,6.06092 0.75762,18.94036 0.75762,18.94036 0,0 26.01142,19.1929 26.26396,26.51651 0.25254,7.3236 -4.04061,19.69797 -9.34391,24.24366 -5.3033,4.54568 -6.31345,6.06091 -6.31345,6.06091 l -0.75762,47.7297 -60.35661,2.0203 c 0,0 11.86929,-13.3845 11.86929,-14.8997 0,-1.5153 -1.51523,-13.6371 -1.51523,-13.6371 l -6.81853,3.7881 2.27285,-19.44546 c 0,0 -18.94036,-4.29315 -18.68783,-21.46574 0.25254,-17.17259 27.52666,-37.88072 27.52666,-37.88072 v -28.03173 z"
+       style="fill:#ffffff;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
+    <path
+       id="path866"
+       d="m 300.625,993.23394 c 0,0 35.31118,-5.3262 35.31118,-32.78581 0,-19.51751 -26.65047,-32.21419 -26.65047,-32.21419 -0.125,-16.5 2.85715,-42.1693 -19.80403,-42.1693 -19.28617,0 -26.98168,17.52644 -26.98168,17.52644 h 11.42857 v 27.5 c 0,0 -28.21428,23.92857 -27.5,39.64286 0.71429,15.71428 23.92857,22.67857 23.92857,22.67857"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <circle
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:2.99999976;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+       id="circle882"
+       cx="285.35715"
+       cy="898.23401"
+       r="1.980318" />
+    <path
+       id="path884"
+       d="m 275,917.96608 4.64286,-4.73214 5.17857,5.17857 4.46428,-4.46429 7.05827,4.07509"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path891"
+       d="m 263.57143,967.69822 12.14286,4.46429"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path898"
+       d="m 263.39286,978.94822 9.30792,4.1994"
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path905"
+       d="m 268.57143,968.94822 v -6.42857 l 14.19769,-3.80426 11.83121,6.83076 8.81207,-5.08766 v 7.77545"
+       style="fill:none;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;marker:none;paint-order:normal" />
+    <path
+       id="path921"
+       d="m 297.5,971.09108 18.30357,-6.69643"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path928"
+       d="m 295.71429,983.59108 8.92857,-3.92857"
+       style="fill:none;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;marker:none;paint-order:normal" />
+    <path
+       id="path935"
+       d="m 265.35714,992.16251 -2.5,17.14289 16.07143,-5 11.78572,6.0714 12.85714,-6.4286 v -10.71426"
+       style="fill:none;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;font-variant-east_asian:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;marker:none;paint-order:normal" />
+    <path
+       id="path942"
+       d="m 282.58928,959.84108 -4.73214,44.10712"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path949"
+       d="m 293.57143,966.5375 -2.14286,42.7679 v 0 0"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path956"
+       d="m 269.64286,1007.5196 c 0.35714,2.1429 1.42857,12.1429 1.42857,12.1429 l -12.14286,15 60.35714,-1.0027 1.39032,-47.04851"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+    <path
+       id="path963"
+       d="m 296.07143,1031.8054 -0.0613,-14.1991"
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#4a90d9;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+  </g>
+</svg>

--- a/src/main.go
+++ b/src/main.go
@@ -31,13 +31,13 @@ func templateHandler(w http.ResponseWriter, r *http.Request) {
 	info, err := os.Stat(content)
 	if err != nil {
 		if os.IsNotExist(err) {
-			http.NotFound(w, r)
+			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
 	}
 
 	if info.IsDir() {
-		http.NotFound(w, r)
+		errorHandler(w, r, http.StatusNotFound)
 		return
 	}
 
@@ -47,6 +47,20 @@ func templateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tmpl.ExecuteTemplate(w, "structure", nil)
+}
+
+func errorHandler(w http.ResponseWriter, r *http.Request, status int) {
+	w.WriteHeader(status)
+	if (status == http.StatusNotFound) {
+		layout := "../templates/structure.html"
+		content := "../pages/notfound.html"
+		tmpl, err := template.ParseFiles(layout, content)
+		if err != nil {
+			http.Error(w, http.StatusText(500), 500)
+			return
+		}
+		tmpl.ExecuteTemplate(w, "structure", nil)
+	}
 }
 
 // main starts the web server and routes URLS.


### PR DESCRIPTION
This adds support for a custom 404 page to the web server and creates one using the same image
that is used on the flatpak.org website. If we merge this, the same change should also be applied
to silverblue-docs.

This closes  #28